### PR TITLE
WEBDEV-5795 Improve accessibility for screen-readers

### DIFF
--- a/src/infinite-scroller.ts
+++ b/src/infinite-scroller.ts
@@ -98,6 +98,9 @@ export class InfiniteScroller
   /** @inheritdoc */
   @property({ type: Boolean }) scrollOptimizationsDisabled = false;
 
+  /** The accessible label for the infinite scroller section landmark */
+  @property({ type: String }) ariaLandmarkLabel?: string;
+
   /**
    * The sentinel is our marker to know when we need to load more data
    *
@@ -244,8 +247,9 @@ export class InfiniteScroller
   render(): TemplateResult {
     const finalIndex = this.itemCount - 1;
     const indexArray = generateRange(0, finalIndex, 1);
+    const containerAriaLabel = this.ariaLandmarkLabel ?? nothing;
     return html`
-      <div id="container" role="feed">
+      <section id="container" role="feed" aria-label=${containerAriaLabel}>
         <div id="sentinel" aria-hidden="true"></div>
         ${repeat(
           indexArray,
@@ -263,7 +267,7 @@ export class InfiniteScroller
             ></article>
           `
         )}
-      </div>
+      </section>
     `;
   }
 

--- a/src/infinite-scroller.ts
+++ b/src/infinite-scroller.ts
@@ -27,13 +27,6 @@ export interface InfiniteScrollerInterface extends LitElement {
   itemCount: number;
 
   /**
-   * In cases where the eventual "full"/"max" item count is known before all cells are
-   * actually displayed, it can be helpful to provide this information to screen-readers
-   * so that they can announce the total size upfront.
-   */
-  predictedFullItemCount?: number;
-
-  /**
    * The cell provider to provide cells for the scroller
    */
   cellProvider?: InfiniteScrollerCellProviderInterface;
@@ -253,7 +246,7 @@ export class InfiniteScroller
     const indexArray = generateRange(0, finalIndex, 1);
     return html`
       <div id="container" role="feed">
-        <div id="sentinel"></div>
+        <div id="sentinel" aria-hidden="true"></div>
         ${repeat(
           indexArray,
           index => index,
@@ -261,7 +254,7 @@ export class InfiniteScroller
             <article
               class="cell-container"
               aria-posinset=${index + 1}
-              aria-setsize=${this.predictedFullItemCount ?? -1}
+              aria-setsize=${this.itemCount}
               data-cell-index=${index}
               @click=${(e: Event) => this.cellSelected(e, index)}
               @keyup=${(e: KeyboardEvent) => {

--- a/src/infinite-scroller.ts
+++ b/src/infinite-scroller.ts
@@ -86,9 +86,6 @@ export class InfiniteScroller
   @property({ type: Number }) itemCount = 0;
 
   /** @inheritdoc */
-  @property({ type: Number }) predictedFullItemCount?: number;
-
-  /** @inheritdoc */
   @property({ type: Object })
   cellProvider?: InfiniteScrollerCellProviderInterface;
 

--- a/src/infinite-scroller.ts
+++ b/src/infinite-scroller.ts
@@ -27,6 +27,13 @@ export interface InfiniteScrollerInterface extends LitElement {
   itemCount: number;
 
   /**
+   * In cases where the eventual "full"/"max" item count is known before all cells are
+   * actually displayed, it can be helpful to provide this information to screen-readers
+   * so that they can announce the total size upfront.
+   */
+  predictedFullItemCount?: number;
+
+  /**
    * The cell provider to provide cells for the scroller
    */
   cellProvider?: InfiniteScrollerCellProviderInterface;
@@ -84,6 +91,9 @@ export class InfiniteScroller
 {
   /** @inheritdoc */
   @property({ type: Number }) itemCount = 0;
+
+  /** @inheritdoc */
+  @property({ type: Number }) predictedFullItemCount?: number;
 
   /** @inheritdoc */
   @property({ type: Object })
@@ -242,20 +252,22 @@ export class InfiniteScroller
     const finalIndex = this.itemCount - 1;
     const indexArray = generateRange(0, finalIndex, 1);
     return html`
-      <div id="container">
+      <div id="container" role="feed">
         <div id="sentinel"></div>
         ${repeat(
           indexArray,
           index => index,
           index => html`
-            <div
+            <article
               class="cell-container"
+              aria-posinset=${index + 1}
+              aria-setsize=${this.predictedFullItemCount ?? -1}
               data-cell-index=${index}
               @click=${(e: Event) => this.cellSelected(e, index)}
               @keyup=${(e: KeyboardEvent) => {
                 if (e.key === 'Enter') this.cellSelected(e, index);
               }}
-            ></div>
+            ></article>
           `
         )}
       </div>


### PR DESCRIPTION
This PR updates the templates to include proper ARIA roles and attributes to properly convey the semantics of the infinite scroller to screen-readers. In particular, the infinite scroller is made to present itself as a scrollable `feed` of `articles`, each with a well-defined position.