### PR TITLE
WEBDEV-6246 Add means of refreshing only visible cells (or specific cells)

### DIFF
--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -23,7 +23,7 @@ export class AppRoot
 
   private showTile(design: '1' | '2') {
     this.tileDesign = design;
-    this.infiniteScroller.reload();
+    this.infiniteScroller.refreshAllVisibleCells();
   }
 
   private scrollThresholdReached() {

--- a/src/infinite-scroller.ts
+++ b/src/infinite-scroller.ts
@@ -334,10 +334,8 @@ export class InfiniteScroller
    * viewable cells, we want to add a buffer on either side to help
    * with scroll performance.
    *
-   * This method updates the render state of cells based on their
-   * visibility, marking those within the buffer range with the
-   * desired content to render (provided cell template or placeholder),
-   * and marking those outside the buffer range for removal.
+   * This methods calculates what cells need to be rendered based
+-  * on the currently visible cells and the size of the buffer.
    *
    * @private
    * @returns

--- a/src/infinite-scroller.ts
+++ b/src/infinite-scroller.ts
@@ -335,7 +335,7 @@ export class InfiniteScroller
    * with scroll performance.
    *
    * This methods calculates what cells need to be rendered based
--  * on the currently visible cells and the size of the buffer.
+   * on the currently visible cells and the size of the buffer.
    *
    * @private
    * @returns

--- a/src/infinite-scroller.ts
+++ b/src/infinite-scroller.ts
@@ -52,6 +52,21 @@ export interface InfiniteScrollerInterface extends LitElement {
   reload(): void;
 
   /**
+   * Refreshes the content of the cell at the given index
+   * @param index Which cell to refresh content for
+   */
+  refreshCell(index: number): void;
+
+  /**
+   * Refreshes the content of all cells within the rendered cell buffer range.
+   *
+   * Prefer this to the more expensive `reload()` when it is only necessary to
+   * propagate a state change in the rendered cell contents and there is no need
+   * for all cells to fully reload (as in the case of a major layout change).
+   */
+  refreshAllVisibleCells(): void;
+
+  /**
    * Scroll to a cell index
    *
    * @param index number
@@ -149,6 +164,20 @@ export class InfiniteScroller
     this.visibleCellIndices.clear();
     this.placeholderCellIndices.clear();
     this.setupObservations();
+  }
+
+  /** @inheritdoc */
+  refreshCell(index: number): void {
+    this.removeCell(index);
+    if (this.bufferRange.includes(index)) {
+      this.renderCellBuffer([index]);
+    }
+  }
+
+  /** @inheritdoc */
+  refreshAllVisibleCells(): void {
+    this.bufferRange.forEach(index => this.removeCell(index));
+    this.renderCellBuffer(this.bufferRange);
   }
 
   /** @inheritdoc */
@@ -279,12 +308,36 @@ export class InfiniteScroller
   }
 
   /**
+   * An array of cell indices that need to be rendered based
+   * on the currently visible cells and the size of the buffer.
+   */
+  private get bufferRange(): number[] {
+    const cellBufferSize = Math.max(10, this.visibleCellIndices.size);
+
+    // if there are no visible cells, use the first `cellBufferSize`
+    const noVisibleCells = this.visibleCellIndices.size === 0;
+    const minVisibleIndex = Math.min(...this.visibleCellIndices);
+    const maxVisibleIndex = Math.max(...this.visibleCellIndices);
+
+    const minBufferIndex = noVisibleCells
+      ? 0
+      : Math.max(minVisibleIndex - cellBufferSize, 0);
+    const maxBufferIndex = noVisibleCells
+      ? cellBufferSize
+      : Math.min(maxVisibleIndex + cellBufferSize, this.itemCount - 1);
+
+    return generateRange(minBufferIndex, maxBufferIndex, 1);
+  }
+
+  /**
    * After the IntersectionObserver processes all of the currently
    * viewable cells, we want to add a buffer on either side to help
    * with scroll performance.
    *
-   * This methods calculates what cells need to be rendered based
-   * on the currently visible cells and the size of the buffer.
+   * This method updates the render state of cells based on their
+   * visibility, marking those within the buffer range with the
+   * desired content to render (provided cell template or placeholder),
+   * and marking those outside the buffer range for removal.
    *
    * @private
    * @returns
@@ -292,22 +345,7 @@ export class InfiniteScroller
    */
   private processVisibleCells() {
     const visibleCellArray = Array.from(this.visibleCellIndices);
-    const cellBufferSize = Math.max(10, visibleCellArray.length);
-    const sortedVisibleRange = visibleCellArray.sort((a, b) =>
-      a > b ? 1 : -1
-    );
-    // if there are no visible cells, use the first `cellBufferSize`
-    const noVisibleCells = visibleCellArray.length === 0;
-    const minIndex = noVisibleCells
-      ? 0
-      : Math.max(sortedVisibleRange[0] - cellBufferSize, 0);
-    const maxIndex = noVisibleCells
-      ? cellBufferSize
-      : Math.min(
-          sortedVisibleRange[sortedVisibleRange.length - 1] + cellBufferSize,
-          this.itemCount - 1
-        );
-    const bufferRange = generateRange(minIndex, maxIndex, 1);
+    const { bufferRange } = this;
     this.renderCellBuffer(bufferRange);
     this.removeCellsOutsideBufferRange(bufferRange);
 

--- a/test/infinite-scroller.test.ts
+++ b/test/infinite-scroller.test.ts
@@ -60,4 +60,58 @@ describe('Infinite Scroller', () => {
     expect((cells?.[1] as HTMLDivElement).innerText).to.equal('cell-1');
     expect((cells?.[2] as HTMLDivElement).innerText).to.equal('cell-2');
   });
+
+  it('refreshes specific cell content when requested', async () => {
+    const cellData = ['foo', 'bar', 'baz'];
+    const cellProvider: InfiniteScrollerCellProviderInterface = {
+      cellForIndex: (index: number): TemplateResult | undefined =>
+        html`cell-${index} ${cellData[index]}`,
+    };
+    const el = await fixture<InfiniteScroller>(
+      html`<infinite-scroller
+        .itemCount=${3}
+        .cellProvider=${cellProvider}
+      ></infinite-scroller>`
+    );
+    const cells = el.shadowRoot?.querySelectorAll('.cell-container');
+
+    // wait for the cells to be populated
+    await promisedSleep(100);
+    expect(cells?.length).to.equal(3);
+
+    cellData.splice(0, 3, 'a', 'b', 'c');
+    el.refreshCell(1);
+    await el.updateComplete;
+
+    expect((cells?.[0] as HTMLDivElement).innerText).to.equal('cell-0 foo');
+    expect((cells?.[1] as HTMLDivElement).innerText).to.equal('cell-1 b');
+    expect((cells?.[2] as HTMLDivElement).innerText).to.equal('cell-2 baz');
+  });
+
+  it('refreshes all visible cell content when requested', async () => {
+    const cellData = ['foo', 'bar', 'baz'];
+    const cellProvider: InfiniteScrollerCellProviderInterface = {
+      cellForIndex: (index: number): TemplateResult | undefined =>
+        html`cell-${index} ${cellData[index]}`,
+    };
+    const el = await fixture<InfiniteScroller>(
+      html`<infinite-scroller
+        .itemCount=${3}
+        .cellProvider=${cellProvider}
+      ></infinite-scroller>`
+    );
+    const cells = el.shadowRoot?.querySelectorAll('.cell-container');
+
+    // wait for the cells to be populated
+    await promisedSleep(100);
+    expect(cells?.length).to.equal(3);
+
+    cellData.splice(0, 3, 'a', 'b', 'c');
+    el.refreshAllVisibleCells();
+    await el.updateComplete;
+
+    expect((cells?.[0] as HTMLDivElement).innerText).to.equal('cell-0 a');
+    expect((cells?.[1] as HTMLDivElement).innerText).to.equal('cell-1 b');
+    expect((cells?.[2] as HTMLDivElement).innerText).to.equal('cell-2 c');
+  });
 });


### PR DESCRIPTION
Performing a full `reload` of the infinite scroller can be a rather expensive update, even with scroll optimizations enabled. Moreover, it can result in a visible flicker in some cases as everything is fully removed and reloaded.

This PR adds two additional public methods: `refreshCell` and `refreshAllVisibleCells`, which restrict the reload to a single cell or only the buffered range of rendered cells, respectively. While `reload` may still be necessary in cases where the entire layout of the scroller is being changed (e.g., changing the display mode), many other cases where we simply want to propagate a change in a cell's rendered tile model can now use the new methods to avoid a lot of unnecessary DOM shuffling & flickering.