### PR TITLE
Upgrade ci action versions to fix codecov reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: latest
+        node-version: 26.x
 
     - name: Install dependencies
       run: yarn install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: latest
 
     - name: Install dependencies
       run: yarn install
@@ -22,5 +22,6 @@ jobs:
     - name: Run tests
       run: yarn run test
 
-    - name: Upload reports
-      run: npx codecov
+    - uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 26.x
+        node-version: 24.x
 
     - name: Install dependencies
       run: yarn install


### PR DESCRIPTION
Updates our Codecov action to a newer version to stop our builds from failing on codecov report upload errors.