### PR TITLE
WEBDEV-8578 Only perform scroll anchoring relative to the scroll container

### DIFF
--- a/src/infinite-scroller.ts
+++ b/src/infinite-scroller.ts
@@ -673,9 +673,15 @@ export class InfiniteScroller
       clearTimeout(this.scrollIdleTimer);
       this.scrollIdleTimer = 0;
     }
+
     // Invalidate any pending anchor restores, since any captured viewport
     // positions are about to be made meaningless by the jump.
     this.scrollAnchor.invalidate();
+
+    // A scrollToCell call should enable scroll anchoring since it is a
+    // deliberate signal that this scroller's position is now important
+    // on the page.
+    this.scrollAnchor.setEnabled(true);
 
     this.snapBufferToCell(index);
 
@@ -1035,6 +1041,10 @@ export class InfiniteScroller
     // We just adjusted scrollTop for scroll anchoring; ignore the
     // resulting event so the recompute doesn't reverse our compensation.
     if (this.scrollAnchor.shouldSuppressNextScrollEvent()) return;
+
+    // Any scroll event we reach here is assumed to have been user-initiated,
+    // so enable scroll anchoring from here on.
+    this.scrollAnchor.setEnabled(true);
 
     if (!this.scrollRafId) {
       this.scrollRafId = requestAnimationFrame(() => {
@@ -1566,7 +1576,16 @@ export class InfiniteScroller
         /**
          * We handle scroll anchoring ourselves for fine-tuning, so opt out
          * of the browser's built-in anchoring (which can interfere with ours
-         * and cause undesirable content jitter).
+         * and cause undesirable content jitter). 
+         */
+        overflow-anchor: none;
+      }
+
+      #scroll-spacer,
+      #container,
+      .cell-container {
+        /**
+         * overflow-anchor does not cascade, so descendents need to opt out too
          */
         overflow-anchor: none;
       }

--- a/src/infinite-scroller.ts
+++ b/src/infinite-scroller.ts
@@ -304,6 +304,7 @@ export class InfiniteScroller
     getCellByIndex: (idx: number) => this.cellContainerForIndex(idx),
     isCellRendered: (cell: Element) => cell.hasAttribute('data-rendered'),
     isActive: () => !this.scrollToCellInProgress,
+    getScrollerTop: () => this.getScrollerTop(),
   });
 
   private sentinelIsIntersecting = false;
@@ -678,11 +679,6 @@ export class InfiniteScroller
     // positions are about to be made meaningless by the jump.
     this.scrollAnchor.invalidate();
 
-    // A scrollToCell call should enable scroll anchoring since it is a
-    // deliberate signal that this scroller's position is now important
-    // on the page.
-    this.scrollAnchor.setEnabled(true);
-
     this.snapBufferToCell(index);
 
     // First we render cells for the buffer range and fill them with content.
@@ -994,6 +990,16 @@ export class InfiniteScroller
   }
 
   /**
+   * Returns the top of the scroller's own content area in the viewport
+   * Used for performing scroll anchoring relative to the scroller itself.
+   */
+  private getScrollerTop(): number {
+    const rectElement = this.scrollSpacer ?? this.container;
+    if (!rectElement) return 0;
+    return rectElement.getBoundingClientRect().top;
+  }
+
+  /**
    * Recompute the two derived scroll-layout values that depend on the
    * current per-row height estimates:
    *  - `totalContentHeight`: the height the scroll spacer needs to be
@@ -1041,10 +1047,6 @@ export class InfiniteScroller
     // We just adjusted scrollTop for scroll anchoring; ignore the
     // resulting event so the recompute doesn't reverse our compensation.
     if (this.scrollAnchor.shouldSuppressNextScrollEvent()) return;
-
-    // Any scroll event we reach here is assumed to have been user-initiated,
-    // so enable scroll anchoring from here on.
-    this.scrollAnchor.setEnabled(true);
 
     if (!this.scrollRafId) {
       this.scrollRafId = requestAnimationFrame(() => {

--- a/src/internal/scroll-anchor.ts
+++ b/src/internal/scroll-anchor.ts
@@ -50,10 +50,8 @@ export interface ScrollAnchorHostInterface {
   isActive(): boolean;
 
   /**
-   * Returns the top of the scroller's own content area in the viewport
-   * (e.g., the scroll spacer's bounding-rect top). Anchor positions are
-   * expressed relative to this so that external layout shifts above the
-   * scroller don't contribute to the restore delta.
+   * Returns the top of the scroller's own content area in the viewport, which
+   * will form the basis for the scroll anchoring.
    */
   getScrollerTop(): number;
 }
@@ -169,11 +167,10 @@ export class ScrollAnchor {
   }
 
   /**
-   * After a state mutation that may have shifted cells within the
-   * scroller, adjust `scrollTop` so the previously-captured anchor cell
-   * stays at the same offset within the scroller. Shifts that moved the
-   * entire scroller (rather than cells within it) produce a delta of
-   * zero and result in no scroll adjustment.
+   * After a state mutation that may have shifted the cells, calling this
+   * will adjust the scroll position so the previously-captured anchor cell
+   * stays at the same offset within the scroller. Does not account for
+   * external layout shifts that moved the entire scroll container.
    */
   restore(anchor: ScrollAnchorPoint | null): void {
     if (!anchor) return;

--- a/src/internal/scroll-anchor.ts
+++ b/src/internal/scroll-anchor.ts
@@ -77,10 +77,25 @@ export class ScrollAnchor {
    */
   private currentValidityKey = 0;
 
+  /**
+   * When false, `capture()` short-circuits to null so that anchoring is a
+   * no-op. This ensures that we don't begin scroll anchoring until the host
+   * is ready (e.g., after other page content that might change the scroll position
+   * has loaded, or after the user has begun scrolling).
+   */
+  private enabled = false;
+
   private host: ScrollAnchorHostInterface;
 
   constructor(host: ScrollAnchorHostInterface) {
     this.host = host;
+  }
+
+  /**
+   * Turns anchoring on or off as needed.
+   */
+  setEnabled(value: boolean): void {
+    this.enabled = value;
   }
 
   /**
@@ -104,6 +119,7 @@ export class ScrollAnchor {
    *  4. The topmost visible placeholder cell as a last-resort fallback.
    */
   capture(): ScrollAnchorPoint | null {
+    if (!this.enabled) return null;
     if (!this.host.isActive()) return null;
 
     const scrollContainer = this.host.getScrollContainer();

--- a/src/internal/scroll-anchor.ts
+++ b/src/internal/scroll-anchor.ts
@@ -1,19 +1,17 @@
 import { isDocumentScroller } from './scroll-container-utils';
 
 /**
- * A captured anchor cell + the viewport-relative `top` position where it
- * was sitting at capture time. Restoring the anchor adjusts `scrollTop`
- * so that the same cell ends up at the same viewport-relative position.
+ * A captured anchor cell + its `top` position relative to its scroll
+ * container at the time the anchor was captured. Restoring the anchor
+ * adjusts the scroll position so that the cell ends up back at the
+ * same offset within the scroller.
  */
 export type ScrollAnchorPoint = {
   cellIndex: number;
-  viewportOffset: number;
   /**
-   * The scroll container's scrollTop at capture time, so that when we
-   * call restore() we can isolate user-initiated scrolling from the
-   * kinds of content shift we're trying to account for.
+   * `cell.top - scroller.top` in viewport coordinates at capture time.
    */
-  scrollYAtCapture: number;
+  cellOffsetWithinScroller: number;
   /**
    * Snapshot of the scroll anchor validity key when this anchor point was
    * captured. If the key gets invalidated (e.g., by a scrollToCell call),
@@ -50,12 +48,22 @@ export interface ScrollAnchorHostInterface {
    * because virtualization is off or a programmatic scroll is in progress.
    */
   isActive(): boolean;
+
+  /**
+   * Returns the top of the scroller's own content area in the viewport
+   * (e.g., the scroll spacer's bounding-rect top). Anchor positions are
+   * expressed relative to this so that external layout shifts above the
+   * scroller don't contribute to the restore delta.
+   */
+  getScrollerTop(): number;
 }
 
 /**
  * Captures and restores a "scroll anchor": a reference to a cell in the
- * buffer, plus its viewport-relative position. The host can use this to
- * keep the user's view stable across operations that shift cell positions.
+ * buffer, plus its position within the scroller's own coordinate space.
+ * The host can use this to keep the user's view of the cells stable
+ * across operations that shift cell positions within the scroller, while
+ * leaving external content shifts (above/around the scroller) alone.
  *
  * Also owns the "suppress next scroll event" flag, which prevents the
  * recursive case where restoring a scroll anchor triggers scroll listeners
@@ -77,25 +85,10 @@ export class ScrollAnchor {
    */
   private currentValidityKey = 0;
 
-  /**
-   * When false, `capture()` short-circuits to null so that anchoring is a
-   * no-op. This ensures that we don't begin scroll anchoring until the host
-   * is ready (e.g., after other page content that might change the scroll position
-   * has loaded, or after the user has begun scrolling).
-   */
-  private enabled = false;
-
   private host: ScrollAnchorHostInterface;
 
   constructor(host: ScrollAnchorHostInterface) {
     this.host = host;
-  }
-
-  /**
-   * Turns anchoring on or off as needed.
-   */
-  setEnabled(value: boolean): void {
-    this.enabled = value;
   }
 
   /**
@@ -109,8 +102,9 @@ export class ScrollAnchor {
   }
 
   /**
-   * Find a cell to use as the scroll anchor and record its
-   * viewport-relative top position. Pair every call with `restore`.
+   * Find a cell to use as the scroll anchor and record its top position
+   * within the scroller's own coordinate space. Pair each call with `restore`
+   * to perform the actual anchoring behavior.
    *
    * The capture prioritizes cells in this order:
    *  1. The topmost visible rendered cell that follows a visible placeholder.
@@ -119,7 +113,6 @@ export class ScrollAnchor {
    *  4. The topmost visible placeholder cell as a last-resort fallback.
    */
   capture(): ScrollAnchorPoint | null {
-    if (!this.enabled) return null;
     if (!this.host.isActive()) return null;
 
     const scrollContainer = this.host.getScrollContainer();
@@ -128,8 +121,8 @@ export class ScrollAnchor {
     const viewportBottom = isDoc
       ? window.innerHeight
       : viewportTop + scrollContainer.clientHeight;
+    const scrollerTop = this.host.getScrollerTop();
     const validityKey = this.currentValidityKey;
-    const scrollYAtCapture = isDoc ? window.scrollY : scrollContainer.scrollTop;
 
     let firstVisibleRendered: ScrollAnchorPoint | null = null;
     let visibleFallback: ScrollAnchorPoint | null = null;
@@ -141,8 +134,7 @@ export class ScrollAnchor {
       const rect = cell.getBoundingClientRect();
       const anchor: ScrollAnchorPoint = {
         cellIndex: parseInt(idxStr, 10),
-        viewportOffset: rect.top - viewportTop,
-        scrollYAtCapture,
+        cellOffsetWithinScroller: rect.top - scrollerTop,
         validityKey,
       };
       if (rect.bottom < viewportTop) {
@@ -177,9 +169,11 @@ export class ScrollAnchor {
   }
 
   /**
-   * After a state mutation that may have shifted the visible content,
-   * adjust `scrollTop` so the previously-captured anchor cell stays at
-   * the same viewport-relative position.
+   * After a state mutation that may have shifted cells within the
+   * scroller, adjust `scrollTop` so the previously-captured anchor cell
+   * stays at the same offset within the scroller. Shifts that moved the
+   * entire scroller (rather than cells within it) produce a delta of
+   * zero and result in no scroll adjustment.
    */
   restore(anchor: ScrollAnchorPoint | null): void {
     if (!anchor) return;
@@ -194,26 +188,17 @@ export class ScrollAnchor {
     const cell = this.host.getCellByIndex(anchor.cellIndex);
     if (!cell) return;
 
-    const scrollContainer = this.host.getScrollContainer();
-    const isDoc = isDocumentScroller(scrollContainer);
-    const viewportTop = isDoc ? 0 : scrollContainer.getBoundingClientRect().top;
+    const scrollerTopNow = this.host.getScrollerTop();
     const newRect = cell.getBoundingClientRect();
-    const scrollYNow = isDoc ? window.scrollY : scrollContainer.scrollTop;
-    // The anchor cell's viewport position may have changed because of
-    // (a) content shifting above it OR (b) the user scrolling.
-    // Here we try to isolate (a) and compensate for it.
-    const userScrollSinceCapture = scrollYNow - anchor.scrollYAtCapture;
-    const delta =
-      newRect.top -
-      viewportTop -
-      anchor.viewportOffset +
-      userScrollSinceCapture;
+    const newCellOffsetWithinScroller = newRect.top - scrollerTopNow;
+    const delta = newCellOffsetWithinScroller - anchor.cellOffsetWithinScroller;
 
     // For very small deltas, we just skip them to avoid scroll jitter.
     if (Math.abs(delta) < 0.5) return;
 
     this.suppressNextScrollEvent = true;
-    if (isDoc) {
+    const scrollContainer = this.host.getScrollContainer();
+    if (isDocumentScroller(scrollContainer)) {
       window.scrollBy(0, delta);
     } else {
       scrollContainer.scrollTop += delta;

--- a/test/infinite-scroller.test.ts
+++ b/test/infinite-scroller.test.ts
@@ -1340,6 +1340,17 @@ describe('Scroll anchoring', () => {
     window.scrollTo(0, 0);
   });
 
+  beforeEach(async () => {
+    // Drain any pending scroll event queued by the previous test's
+    // afterEach `scrollTo(0, 0)`. Browsers dispatch scroll events on
+    // a later tick, so without this the event can land after the next
+    // test's scroller mounts and enable anchoring prematurely.
+    // This is purely an artifact of the test-harness.
+    window.scrollTo(0, 0);
+    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => requestAnimationFrame(() => r(undefined)));
+  });
+
   it('ScrollAnchor.capture + restore compensate for layout shifts', async () => {
     // Unit test of the ScrollAnchor primitives directly: an anchor
     // captured before a simulated layout shift should drive a scrollTop
@@ -1829,5 +1840,117 @@ describe('Scroll anchoring', () => {
       wrongCachedValue,
       `articles with min-height not reflecting cached row height: ${JSON.stringify(wrongCachedValue.slice(0, 3))}`,
     ).to.deep.equal([]);
+  });
+
+  it('does not anchor before interaction/scrollToCell', async () => {
+    const heights = new Map<number, number>();
+    const cellProvider: InfiniteScrollerCellProviderInterface = {
+      cellForIndex(i: number): TemplateResult | undefined {
+        const h = heights.get(i);
+        if (h === undefined) return undefined;
+        return html`<div style="height:${h}px">cell-${i}</div>`;
+      },
+    };
+    const wrapper = await fixture<HTMLElement>(html`
+      <div>
+        <div id="header" style="height:50px">short header</div>
+        <infinite-scroller
+          style="--infiniteScrollerCellMinHeight:0"
+          .itemCount=${500}
+          .cellProvider=${cellProvider}
+          .placeholderCellTemplate=${html`<div style="height:30px">
+            loading
+          </div>`}
+        ></infinite-scroller>
+      </div>
+    `);
+    const el = wrapper.querySelector('infinite-scroller') as InfiniteScroller;
+    await el.bufferStabilized;
+
+    expect(window.scrollY, 'page must start at top').to.equal(0);
+
+    // Consumer's data arrives at the same time as the tall header content,
+    // mimicking the production paint cycle.
+    for (let i = 0; i <= 50; i += 1) heights.set(i, 100);
+    for (let i = 0; i <= 50; i += 1) el.refreshCell(i);
+    const header = wrapper.querySelector('#header') as HTMLElement;
+    header.style.height = '450px';
+
+    await el.updateComplete;
+    await waitForFrame();
+    await el.updateComplete;
+
+    expect(
+      window.scrollY,
+      `page should remain at top; got scrollY=${window.scrollY}`,
+    ).to.be.lessThan(20);
+  });
+
+  it('enables anchoring once the user scrolls', async () => {
+    // Companion to the test above: after a user scroll, in-scroller content
+    // shifts should once again be compensated by anchoring. This guards
+    // against accidentally leaving the anchor disabled forever.
+    const heights = new Map<number, number>();
+    const cellProvider: InfiniteScrollerCellProviderInterface = {
+      cellForIndex(i: number): TemplateResult | undefined {
+        const h = heights.get(i);
+        if (h === undefined) return undefined;
+        return html`<div style="height:${h}px">cell-${i}</div>`;
+      },
+    };
+    const el = await fixture<InfiniteScroller>(
+      html`<infinite-scroller
+        style="--infiniteScrollerCellMinHeight:0"
+        .itemCount=${500}
+        .cellProvider=${cellProvider}
+        .placeholderCellTemplate=${html`<div style="height:30px">loading</div>`}
+      ></infinite-scroller>`,
+    );
+    await el.bufferStabilized;
+
+    // Render the visible region so we have non-placeholder cells to anchor on.
+    for (let i = 0; i <= 60; i += 1) heights.set(i, 100);
+    for (let i = 0; i <= 60; i += 1) el.refreshCell(i);
+    await el.updateComplete;
+    await waitForFrame();
+    await el.updateComplete;
+
+    // Simulate a user scroll, which should enable the anchoring.
+    window.scrollTo(0, 300);
+    await waitForFrame();
+
+    // Find a visible rendered cell and record its viewport-relative top.
+    const cells = cellsOf(el);
+    let anchorCell: HTMLElement | null = null;
+    for (const cell of cells) {
+      const r = cell.getBoundingClientRect();
+      const idx = Number(cell.dataset.cellIndex);
+      if (r.bottom > 0 && r.top < window.innerHeight && heights.has(idx)) {
+        anchorCell = cell;
+        break;
+      }
+    }
+    expect(anchorCell, 'visible rendered cell').to.not.be.null;
+    const anchorIndex = Number(anchorCell!.dataset.cellIndex);
+    const topBefore = anchorCell!.getBoundingClientRect().top;
+
+    // Grow cells above the viewport; anchoring should compensate so the
+    // chosen anchor cell stays at the same viewport-relative position.
+    for (let i = 0; i <= 2; i += 1) heights.set(i, 400);
+    for (let i = 0; i <= 2; i += 1) el.refreshCell(i);
+    await el.updateComplete;
+    await waitForFrame();
+    await el.updateComplete;
+
+    const anchorCellAfter = el.shadowRoot?.querySelector(
+      `.cell-container[data-cell-index="${anchorIndex}"]`,
+    ) as HTMLElement | null;
+    expect(anchorCellAfter, 'anchor cell still in buffer').to.not.be.null;
+    const topAfter = anchorCellAfter!.getBoundingClientRect().top;
+    const delta = topAfter - topBefore;
+    expect(
+      Math.abs(delta),
+      `anchor cell ${anchorIndex} shifted ${delta.toFixed(1)}px after enabling`,
+    ).to.be.lessThan(20);
   });
 });

--- a/test/infinite-scroller.test.ts
+++ b/test/infinite-scroller.test.ts
@@ -1340,17 +1340,6 @@ describe('Scroll anchoring', () => {
     window.scrollTo(0, 0);
   });
 
-  beforeEach(async () => {
-    // Drain any pending scroll event queued by the previous test's
-    // afterEach `scrollTo(0, 0)`. Browsers dispatch scroll events on
-    // a later tick, so without this the event can land after the next
-    // test's scroller mounts and enable anchoring prematurely.
-    // This is purely an artifact of the test-harness.
-    window.scrollTo(0, 0);
-    await new Promise(r => setTimeout(r, 0));
-    await new Promise(r => requestAnimationFrame(() => r(undefined)));
-  });
-
   it('ScrollAnchor.capture + restore compensate for layout shifts', async () => {
     // Unit test of the ScrollAnchor primitives directly: an anchor
     // captured before a simulated layout shift should drive a scrollTop
@@ -1384,9 +1373,10 @@ describe('Scroll anchoring', () => {
     expect(anchor.cellIndex, 'anchor.cellIndex should be a number').to.be.a(
       'number',
     );
-    expect(anchor.viewportOffset, 'viewportOffset should be a number').to.be.a(
-      'number',
-    );
+    expect(
+      anchor.cellOffsetWithinScroller,
+      'cellOffsetWithinScroller should be a number',
+    ).to.be.a('number');
 
     // Simulate a layout shift: change the container's translateY,
     // which moves the anchor cell up in the viewport by 200px.
@@ -1842,7 +1832,10 @@ describe('Scroll anchoring', () => {
     ).to.deep.equal([]);
   });
 
-  it('does not anchor before interaction/scrollToCell', async () => {
+  it('does not compensate for external layout shifts above the scroller', async () => {
+    // Anchor positions should be measured relative to the scroll container,
+    // so changing the height of an external element above the scroller should
+    // not trigger scroll anchoring compensation.
     const heights = new Map<number, number>();
     const cellProvider: InfiniteScrollerCellProviderInterface = {
       cellForIndex(i: number): TemplateResult | undefined {
@@ -1886,10 +1879,10 @@ describe('Scroll anchoring', () => {
     ).to.be.lessThan(20);
   });
 
-  it('enables anchoring once the user scrolls', async () => {
-    // Companion to the test above: after a user scroll, in-scroller content
-    // shifts should once again be compensated by anchoring. This guards
-    // against accidentally leaving the anchor disabled forever.
+  it('compensates for internal layout shifts above the viewport', async () => {
+    // Opposite case to the above test: when cells INSIDE the scroller
+    // the scroller grow, the we SHOULD compensate for the shift via
+    // scroll anchoring on the visible cells.
     const heights = new Map<number, number>();
     const cellProvider: InfiniteScrollerCellProviderInterface = {
       cellForIndex(i: number): TemplateResult | undefined {
@@ -1915,7 +1908,6 @@ describe('Scroll anchoring', () => {
     await waitForFrame();
     await el.updateComplete;
 
-    // Simulate a user scroll, which should enable the anchoring.
     window.scrollTo(0, 300);
     await waitForFrame();
 
@@ -1950,7 +1942,7 @@ describe('Scroll anchoring', () => {
     const delta = topAfter - topBefore;
     expect(
       Math.abs(delta),
-      `anchor cell ${anchorIndex} shifted ${delta.toFixed(1)}px after enabling`,
+      `anchor cell ${anchorIndex} shifted ${delta.toFixed(1)}px in viewport`,
     ).to.be.lessThan(20);
   });
 });


### PR DESCRIPTION
Currently the scroll anchoring takes effect as soon as the infinite scroller is rendered, relative to the viewport. This is not always desirable -- particularly when other content above to the scroller may change its viewport position while loading in. With the current behavior, the anchoring may cause the page to automatically scroll down past other content, in a misguided attempt to maintain the same viewport coords for the cells inside the scroller.

This PR adjust the scroll anchoring to be strictly relative to the scroll container instead of the viewport, ensuring that we only perform anchoring for content shifts _inside_ the scroller, not for shifts caused by content outside of it.